### PR TITLE
feat(docs): add LLM integration vision document

### DIFF
--- a/docs/llm_integration_vision.md
+++ b/docs/llm_integration_vision.md
@@ -1,0 +1,76 @@
+# Vision for LLM Integration in QuantaSynapse
+
+This document outlines a vision for the deeper integration of Large Language Model (LLM) capabilities within the Quanta ecosystem, with QuantaSynapse acting as the central nervous system for this intelligence. Our goal is to evolve QuantaSynapse from a simple message bus into an intelligent, context-aware communication fabric.
+
+This vision focuses on three key areas:
+1.  **Enhanced Integration with `quanta_tissu` (The Core LLM):** Streamlining and optimizing how components interact with the primary language model.
+2.  **Synergy with `quanta_glia` (The Knowledge Engine):** Leveraging the ecosystem's collective knowledge to enrich communication.
+3.  **Embedding Intelligence into `QuantaSynapse`:** Making the bus itself intelligent.
+
+---
+
+## 1. Enhanced Integration with `quanta_tissu` (The Core LLM)
+
+To facilitate more powerful and efficient use of the `quanta_tissu` language model across the ecosystem, we propose the following enhancements to QuantaSynapse:
+
+### New Signal Types for LLM Tasks
+
+We will introduce a set of standardized `Signal` types for common LLM interactions:
+
+*   **`llm_prompt`**: A signal for sending a prompt to `quanta_tissu`. It will include parameters for controlling the generation process (e.g., `max_tokens`, `temperature`).
+*   **`llm_response`**: A signal for receiving the generated text from `quanta_tissu`.
+*   **`llm_finetune_data`**: A signal for sending data to `quanta_tissu` for fine-tuning, allowing the model to learn from the ecosystem's activities.
+*   **`llm_analysis_request`**: A signal for requesting analysis of a piece of text (e.g., sentiment analysis, entity extraction).
+*   **`llm_analysis_response`**: A signal for receiving the results of the analysis.
+
+### Dedicated Topics for LLM Services
+
+We will establish a dedicated set of topics for LLM services to ensure that requests are routed efficiently:
+
+*   `services.llm.generation`: For text generation tasks.
+*   `services.llm.analysis`: For text analysis tasks.
+*   `services.llm.finetuning`: For model fine-tuning.
+
+### Handling Large Data Payloads
+
+LLM responses can be large. QuantaSynapse will need a mechanism to handle large data payloads efficiently. This could involve:
+*   **Chunking:** Automatically splitting large messages into smaller chunks and reassembling them at the destination.
+*   **Reference-based messaging:** Storing the large payload in a dedicated data store (like `quanta_memora`) and sending a reference to it in the signal.
+
+---
+
+## 2. Synergy with `quanta_glia` (The Knowledge Engine)
+
+`quanta_glia` builds a knowledge base from the events flowing through the ecosystem. We can leverage this knowledge to make our system more intelligent.
+
+### Contextual Signal Enrichment
+
+QuantaSynapse could be configured to automatically query `quanta_glia` to enrich signals with relevant context. For example, when a signal is sent from `prismquanta`, QuantaSynapse could query `quanta_glia` for related rules or historical data and attach it to the signal before forwarding it.
+
+### System State Awareness
+
+`quanta_glia` can provide a "system state awareness" service, accessible via QuantaSynapse. Other components could query this service to get a high-level understanding of what is happening in the ecosystem, enabling them to make more informed decisions.
+
+---
+
+## 3. Embedding Intelligence into `QuantaSynapse`
+
+We propose embedding LLM capabilities directly into QuantaSynapse to create an intelligent communication bus.
+
+### Intelligent Routing
+
+Instead of relying solely on topic-based routing, QuantaSynapse could use an LLM to analyze the content of a signal and route it to the most appropriate component, even if the sender does not explicitly know the receiver. This would enable more dynamic and flexible workflows.
+
+### Automated Content Summarization
+
+For high-volume topics, QuantaSynapse could use an LLM to automatically generate summaries of the messages. This would allow components to quickly get the gist of what is happening without having to process every single message.
+
+### Ethical Scoring Assistance
+
+The `ethicsScore` is a key feature of our ecosystem. An LLM could be used to analyze the content of a signal and suggest an initial `ethicsScore`. This score would then be validated by `quanta_ethos`, providing an extra layer of safety and review.
+
+---
+
+## Conclusion
+
+By deepening the integration with `quanta_tissu`, leveraging the knowledge of `quanta_glia`, and embedding intelligence directly into QuantaSynapse, we can transform it from a simple message bus into the intelligent heart of the Quanta ecosystem. This will enable more powerful, flexible, and context-aware applications, ultimately accelerating the progress of the entire Quanta project.


### PR DESCRIPTION
This commit adds a new document, docs/llm_integration_vision.md, which outlines a vision for deeper integration of Large Language Model (LLM) capabilities within the Quanta ecosystem.

The document covers three main areas:
- Enhanced integration with quanta_tissu (the core LLM)
- Synergy with quanta_glia (the knowledge engine)
- Embedding intelligence into QuantaSynapse itself