### PR TITLE
feat(docs): add LLM integration implementation plan

### DIFF
--- a/docs/llm_integration_plan.md
+++ b/docs/llm_integration_plan.md
@@ -1,0 +1,107 @@
+# LLM Integration Implementation Plan
+
+This document provides a detailed implementation plan for the vision outlined in `llm_integration_vision.md`. It breaks down the vision into actionable phases and tasks.
+
+---
+
+## Phase 1: Core LLM Integration (`quanta_tissu`)
+
+This phase focuses on building the foundational components for seamless interaction with the `quanta_tissu` language model.
+
+### Task 1.1: Define and Implement New Signal Types
+
+*   **Objective:** Standardize the data structures for LLM-related communication.
+*   **Actions:**
+    1.  Define a formal schema (e.g., JSON Schema or XSD) for the new `Signal` types: `llm_prompt`, `llm_response`, `llm_finetune_data`, `llm_analysis_request`, and `llm_analysis_response`. The schema will be stored in a shared repository.
+    2.  Create a new header file, `cpp/include/LLMSignal.h`, to define the C++ structs for these new signal types. These structs will be derived from or compose the base `Signal` struct.
+    3.  Update the C++ `QuantaSynapse` library to handle the serialization and deserialization of these new signal types.
+    4.  Update the Python `quanta_synapse` library to provide classes for these new signal types and handle their serialization/deserialization.
+    5.  Create example usage snippets in the documentation for both C++ and Python.
+*   **Deliverables:**
+    *   Schema file for LLM signals.
+    *   `LLMSignal.h` file.
+    *   Updated C++ and Python libraries.
+    *   Documentation with examples.
+
+### Task 1.2: Establish Dedicated LLM Topics
+
+*   **Objective:** Create a well-defined topic structure for routing LLM-related signals.
+*   **Actions:**
+    1.  Formally document the new topic hierarchy: `services.llm.generation`, `services.llm.analysis`, and `services.llm.finetuning`.
+    2.  Update the message bus configuration (e.g., RabbitMQ or ZeroMQ) to support these new topics and any required routing rules.
+    3.  Update the `quanta_tissu` wrapper to subscribe to these topics.
+*   **Deliverables:**
+    *   Updated documentation for the topic hierarchy.
+    *   Updated message bus configuration.
+
+### Task 1.3: Implement Large Payload Handling
+
+*   **Objective:** Ensure `QuantaSynapse` can handle large data payloads from LLM responses.
+*   **Actions:**
+    1.  Design a chunking mechanism. This will involve defining a chunking protocol to split large messages into smaller parts and reassemble them at the destination.
+    2.  Alternatively, design a reference-based messaging system. This will involve integrating with a data store like `quanta_memora` to store large payloads and pass references in the signals.
+    3.  Implement the chosen mechanism in both the C++ and Python `QuantaSynapse` libraries.
+*   **Deliverables:**
+    *   Design document for the large payload handling mechanism.
+    *   Updated C++ and Python libraries with the implementation.
+
+---
+
+## Phase 2: Knowledge Integration (`quanta_glia`)
+
+This phase focuses on leveraging the `quanta_glia` knowledge management system to enrich communication.
+
+### Task 2.1: Develop Contextual Enrichment Service
+
+*   **Objective:** Enable `QuantaSynapse` to automatically enrich signals with relevant context from `quanta_glia`.
+*   **Actions:**
+    1.  Define a clear API for querying `quanta_glia` for contextual information related to a signal.
+    2.  Implement the service in `QuantaSynapse` as an optional middleware component. This component will intercept signals, query `quanta_glia`, and attach the retrieved context to the signal's content.
+*   **Deliverables:**
+    *   API documentation for the `quanta_glia` query service.
+    *   Contextual enrichment middleware in `QuantaSynapse`.
+
+### Task 2.2: Create System State Awareness API
+
+*   **Objective:** Provide a way for components to get a high-level overview of the ecosystem's state from `quanta_glia`.
+*   **Actions:**
+    1.  Define the API for the system state awareness service. This API will provide access to key metrics and trends from `quanta_glia`.
+    2.  Implement this service in `quanta_glia` and expose it via a dedicated topic in `QuantaSynapse`.
+*   **Deliverables:**
+    *   API documentation for the system state awareness service.
+    *   Implementation of the service in `quanta_glia`.
+
+---
+
+## Phase 3: Intelligent `QuantaSynapse`
+
+This phase focuses on embedding LLM capabilities directly into `QuantaSynapse`.
+
+### Task 3.1: Implement Intelligent Routing
+
+*   **Objective:** Use an LLM to enable content-based routing of signals.
+*   **Actions:**
+    1.  Prototype a routing service that takes a signal, uses `quanta_tissu` to determine the most appropriate destination component, and forwards the signal.
+    2.  Integrate this service into `QuantaSynapse` as a new routing strategy.
+*   **Deliverables:**
+    *   Prototype of the intelligent routing service.
+    *   Integration of the service into `QuantaSynapse`.
+
+### Task 3.2: Implement Content Summarization
+
+*   **Objective:** Provide automated summaries for high-volume topics.
+*   **Actions:**
+    1.  Develop a summarization service that subscribes to specified high-volume topics.
+    2.  This service will use `quanta_tissu` to generate periodic summaries and publish them to a new `.summary` sub-topic.
+*   **Deliverables:**
+    *   Summarization service.
+
+### Task 3.3: Implement Ethical Scoring Assistance
+
+*   **Objective:** Use an LLM to assist in the ethical scoring of signals.
+*   **Actions:**
+    1.  Create a service that analyzes the content of a signal and suggests an initial `ethicsScore`.
+    2.  Integrate this service with `quanta_ethos`, which will have the final say on the score. The suggested score will be passed to `quanta_ethos` for validation.
+*   **Deliverables:**
+    *   Ethical scoring assistance service.
+    *   Integration with `quanta_ethos`.

--- a/docs/llm_integration_vision.md
+++ b/docs/llm_integration_vision.md
@@ -1,0 +1,76 @@
+# Vision for LLM Integration in QuantaSynapse
+
+This document outlines a vision for the deeper integration of Large Language Model (LLM) capabilities within the Quanta ecosystem, with QuantaSynapse acting as the central nervous system for this intelligence. Our goal is to evolve QuantaSynapse from a simple message bus into an intelligent, context-aware communication fabric.
+
+This vision focuses on three key areas:
+1.  **Enhanced Integration with `quanta_tissu` (The Core LLM):** Streamlining and optimizing how components interact with the primary language model.
+2.  **Synergy with `quanta_glia` (The Knowledge Engine):** Leveraging the ecosystem's collective knowledge to enrich communication.
+3.  **Embedding Intelligence into `QuantaSynapse`:** Making the bus itself intelligent.
+
+---
+
+## 1. Enhanced Integration with `quanta_tissu` (The Core LLM)
+
+To facilitate more powerful and efficient use of the `quanta_tissu` language model across the ecosystem, we propose the following enhancements to QuantaSynapse:
+
+### New Signal Types for LLM Tasks
+
+We will introduce a set of standardized `Signal` types for common LLM interactions:
+
+*   **`llm_prompt`**: A signal for sending a prompt to `quanta_tissu`. It will include parameters for controlling the generation process (e.g., `max_tokens`, `temperature`).
+*   **`llm_response`**: A signal for receiving the generated text from `quanta_tissu`.
+*   **`llm_finetune_data`**: A signal for sending data to `quanta_tissu` for fine-tuning, allowing the model to learn from the ecosystem's activities.
+*   **`llm_analysis_request`**: A signal for requesting analysis of a piece of text (e.g., sentiment analysis, entity extraction).
+*   **`llm_analysis_response`**: A signal for receiving the results of the analysis.
+
+### Dedicated Topics for LLM Services
+
+We will establish a dedicated set of topics for LLM services to ensure that requests are routed efficiently:
+
+*   `services.llm.generation`: For text generation tasks.
+*   `services.llm.analysis`: For text analysis tasks.
+*   `services.llm.finetuning`: For model fine-tuning.
+
+### Handling Large Data Payloads
+
+LLM responses can be large. QuantaSynapse will need a mechanism to handle large data payloads efficiently. This could involve:
+*   **Chunking:** Automatically splitting large messages into smaller chunks and reassembling them at the destination.
+*   **Reference-based messaging:** Storing the large payload in a dedicated data store (like `quanta_memora`) and sending a reference to it in the signal.
+
+---
+
+## 2. Synergy with `quanta_glia` (The Knowledge Engine)
+
+`quanta_glia` builds a knowledge base from the events flowing through the ecosystem. We can leverage this knowledge to make our system more intelligent.
+
+### Contextual Signal Enrichment
+
+QuantaSynapse could be configured to automatically query `quanta_glia` to enrich signals with relevant context. For example, when a signal is sent from `prismquanta`, QuantaSynapse could query `quanta_glia` for related rules or historical data and attach it to the signal before forwarding it.
+
+### System State Awareness
+
+`quanta_glia` can provide a "system state awareness" service, accessible via QuantaSynapse. Other components could query this service to get a high-level understanding of what is happening in the ecosystem, enabling them to make more informed decisions.
+
+---
+
+## 3. Embedding Intelligence into `QuantaSynapse`
+
+We propose embedding LLM capabilities directly into QuantaSynapse to create an intelligent communication bus.
+
+### Intelligent Routing
+
+Instead of relying solely on topic-based routing, QuantaSynapse could use an LLM to analyze the content of a signal and route it to the most appropriate component, even if the sender does not explicitly know the receiver. This would enable more dynamic and flexible workflows.
+
+### Automated Content Summarization
+
+For high-volume topics, QuantaSynapse could use an LLM to automatically generate summaries of the messages. This would allow components to quickly get the gist of what is happening without having to process every single message.
+
+### Ethical Scoring Assistance
+
+The `ethicsScore` is a key feature of our ecosystem. An LLM could be used to analyze the content of a signal and suggest an initial `ethicsScore`. This score would then be validated by `quanta_ethos`, providing an extra layer of safety and review.
+
+---
+
+## Conclusion
+
+By deepening the integration with `quanta_tissu`, leveraging the knowledge of `quanta_glia`, and embedding intelligence directly into QuantaSynapse, we can transform it from a simple message bus into the intelligent heart of the Quanta ecosystem. This will enable more powerful, flexible, and context-aware applications, ultimately accelerating the progress of the entire Quanta project.


### PR DESCRIPTION
This commit adds a new document, docs/llm_integration_plan.md, which provides a detailed, phased implementation plan for the vision outlined in llm_integration_vision.md.

The plan breaks down the vision into actionable phases and tasks, covering:
- Phase 1: Core LLM Integration (quanta_tissu)
- Phase 2: Knowledge Integration (quanta_glia)
- Phase 3: Intelligent QuantaSynapse