### PR TITLE
docs: Add section on active vs. passive publishing

### DIFF
--- a/docs/publisher_subscriber_architecture.md
+++ b/docs/publisher_subscriber_architecture.md
@@ -1,0 +1,135 @@
+# QuantaSynapse Publisher-Subscriber Architecture
+
+## 1. Introduction
+
+The QuantaSynapse system is architected around a highly decoupled, message-driven paradigm known as the **Publisher-Subscriber (Pub/Sub) model**. This architectural choice is fundamental to the Quanta ecosystem's integration strategy, providing a robust and scalable framework for asynchronous communication among its diverse set of projects.
+
+The core principle of this architecture is the separation of concerns between message producers (publishers) and message consumers (subscribers). This separation fosters loose coupling, allowing individual projects to be developed, deployed, and scaled independently without creating direct dependencies on other systems. This document provides a verbose and detailed exploration of this architecture, its components, and the underlying design principles.
+
+## 2. Architectural Goals
+
+The selection of the Pub/Sub model was driven by several key architectural goals:
+
+*   **Loose Coupling:** To avoid a "spaghetti architecture" of point-to-point connections, the pub/sub model ensures that projects do not need direct knowledge of each other. A publisher only needs to know which topic to publish to, and a subscriber only needs to know which topic to listen to.
+*   **Scalability:** The asynchronous nature of the message queue allows the system to handle fluctuating loads. Publishers can produce messages without waiting for subscribers to be ready. New subscriber instances can be added to handle increased message volume on a topic without any changes to the publishers.
+*   **Resilience and Reliability:** The message queue acts as a buffer, holding messages until they can be successfully processed. This ensures that messages are not lost if a subscriber is temporarily unavailable. Features like message persistence and acknowledgments provide guarantees for message delivery.
+*   **Flexibility and Extensibility:** New projects can be easily integrated into the ecosystem by simply subscribing to relevant topics and publishing their own events. Existing projects can be extended with new functionality by adding new subscriptions without modifying the core logic of other components.
+
+## 3. Core Components
+
+The Pub/Sub architecture is composed of several key components that work in concert to facilitate communication.
+
+### 3.1. Publishers
+
+A **publisher** is any component within the Quanta ecosystem that sends messages. Publishers are responsible for constructing messages, assigning them to a topic, and sending them to the central message queue.
+
+*   **Examples of Publishers:**
+    *   `quanta_prism`: Publishes an event to `events.prismquanta.rule.created` whenever a new analysis rule is defined.
+    *   `quanta_sensa`: Publishes a command to `commands.quanta_tissu.process.text` to request natural language processing.
+    *   `quanta_pulsa`: Publishes a metric to `metrics.system.cpu.load` every second.
+*   **Responsibilities:** Publishers are concerned only with the "what" (the message content and topic), not the "who" or "how" of message delivery. The API wrappers provided by QuantaSynapse abstract the low-level details of serialization to XML and connection to the message queue.
+
+### 3.2. Subscribers
+
+A **subscriber** is any component that expresses interest in one or more topics and receives messages published to them.
+
+*   **Examples of Subscribers:**
+    *   `quanta_alarma`: Subscribes to `events.prismquanta.rule.created` to monitor for potentially problematic rules.
+    *   `quanta_tissu`: Subscribes to `commands.quanta_tissu.process.text` to receive and act upon text processing commands.
+    *   `quanta_cerebra`: Subscribes to `metrics.system.cpu.load` using a wildcard (`metrics.system.*`) to visualize system performance metrics.
+*   **Subscription Patterns:** Subscribers can use specific topic names for fine-grained control or wildcards to subscribe to a whole class of topics, enabling powerful and flexible message consumption patterns.
+
+### 3.3. Topics
+
+**Topics** are named channels that categorize messages. They form the backbone of the routing system, allowing the message queue to deliver messages from publishers to the correct subscribers.
+
+*   **Naming Convention:** QuantaSynapse employs a hierarchical, dot-delimited naming convention for topics (e.g., `category.source_project.entity.action`). This structure provides a clear and organized topic space.
+*   **Example Hierarchy:**
+    *   `events.prismquanta.rule.created`
+    *   `events.prismquanta.rule.deleted`
+    *   `commands.quanta_cerebra.visualization.update`
+    *   `queries.quanta_glia.knowledge.fetch`
+*   **Function:** This structured approach allows subscribers to listen to very specific events (e.g., only rule creations) or broad categories of events (e.g., all events from `prismquanta` via `events.prismquanta.#`).
+
+### 3.4. The Message Queue
+
+The **Message Queue** is the central nervous system of the architecture. It is a dedicated software component (e.g., RabbitMQ, ZeroMQ) that acts as a broker for all messages.
+
+*   **Core Responsibilities:**
+    *   Accepting incoming messages from publishers.
+    *   Determining which subscribers are interested in each message based on topic subscriptions.
+    *   Reliably delivering the message to all interested subscribers.
+*   **Reliability Features:**
+    *   **Message Persistence:** The queue can store messages on disk, ensuring that they survive a broker restart and can be delivered to late-joining subscribers.
+    *   **Delivery Guarantees:** The system is configured for "at-least-once" delivery, meaning a message will be re-delivered until the subscriber formally acknowledges its receipt.
+
+## 4. The Message Lifecycle
+
+A message travels through several distinct stages from its creation to its consumption:
+
+1.  **Creation & Serialization:** A publisher (e.g., `quanta_prism`) decides to send an event. It constructs a message in its native data format. The QuantaSynapse API wrapper then serializes this object into the standardized XML format.
+2.  **Schema Validation:** Before publishing, the XML message is validated against its corresponding XSD schema. This is a critical step to ensure data integrity and prevent malformed messages from entering the system. If validation fails, the message is rejected and an error is logged.
+3.  **Publication:** The valid XML message, along with its target topic (e.g., `events.prismquanta.rule.created`), is sent to the message queue. The publisher's job is now complete.
+4.  **Routing:** The message queue receives the message. It consults its internal registry of subscriptions and identifies all subscribers that are listening to the specified topic.
+5.  **Delivery & Deserialization:** The message queue delivers a copy of the message to each identified subscriber. The subscriber's QuantaSynapse API wrapper receives the raw XML message and deserializes it back into an object native to the subscriber's language (e.g., a C++ or Python object).
+6.  **Processing:** The subscriber's business logic now processes the message. This could involve triggering an alert, updating a UI, or storing data.
+7.  **Acknowledgment (Ack):** After the subscriber has successfully processed the message, it sends an acknowledgment back to the message queue. This "Ack" signal informs the queue that the message has been handled and can be safely deleted.
+
+## 5. Error Handling and Resilience
+
+*   **Negative Acknowledgment (Nack):** If a subscriber fails to process a message, it can send a "Nack" signal to the queue. This tells the queue that processing failed, and the queue might be configured to re-queue the message for another attempt.
+*   **Dead Letter Queue (DLQ):** If a message repeatedly fails processing, or if it is published to a topic with no subscribers, it is not simply discarded. Instead, it is routed to a special topic known as a **Dead Letter Queue**. This allows system administrators to inspect failed messages, debug the root cause of the failure, and potentially re-process them manually.
+*   **Circuit Breaker:** For services that are repeatedly failing, a Circuit Breaker pattern may be implemented at the subscriber level to prevent it from continuously attempting to process messages from a faulty upstream source, thus reducing system load and cascading failures.
+
+## 6. Architectural Trade-offs
+
+While powerful, the Pub/Sub model is not without its trade-offs:
+
+*   **Increased Latency:** Communication through a broker will almost always have higher latency than a direct, point-to-point call. This architecture prioritizes decoupling and resilience over raw speed.
+*   **Operational Complexity:** A message broker is another piece of critical infrastructure that must be deployed, configured, monitored, and maintained.
+*   **Message Ordering:** While messages within a single topic are generally delivered in the order they were received, guaranteeing strict end-to-end ordering across a distributed system is a complex problem. The architecture guarantees at-least-once delivery, which can sometimes result in duplicate messages that subscribers must be prepared to handle (i.e., by being idempotent).
+*   **Debugging:** Tracing a single logical flow of events across multiple decoupled services can be more challenging than debugging a monolithic application. This is mitigated by extensive logging and distributed tracing mechanisms.
+
+## 7. Publishing Models: Active vs. Passive
+
+Within the QuantaSynapse ecosystem, publishing can be categorized into two distinct models: Active and Passive. This distinction refers to how a message is generated and sent by a service.
+
+### 7.1. Active Publishing
+
+**Active Publishing** occurs when a service's business logic makes a direct, explicit decision to send a message. The act of publishing is a primary part of the operation being performed. The code contains a specific call to the QuantaSynapse publisher client at the moment the event occurs.
+
+*   **Characteristics:**
+    *   **Intentional:** The publisher is fully aware that it is generating an event for others to consume.
+    *   **Explicit:** The `publish()` call is visible and integral to the business logic workflow.
+    *   **Event-Driven:** Typically tied to specific actions, commands, or state transitions within the application logic.
+
+*   **Example:**
+    The `quanta_lista` task management system receives a user request to create a new task. After successfully validating and saving the new task to its database, its code explicitly constructs a `task.created` event message and publishes it to the message bus. This is an active, intentional broadcast of an event that just occurred.
+
+    ```
+    // Pseudocode for Active Publishing
+    function createTask(taskDetails) {
+      // ... business logic to save the task ...
+      saveTaskToDatabase(taskDetails);
+
+      // Actively publish an event
+      const eventMessage = createEventMessage("task.created", taskDetails);
+      QuantaSynapse.publish("events.quanta_lista.task.created", eventMessage);
+
+      return "Task created successfully";
+    }
+    ```
+
+### 7.2. Passive Publishing
+
+**Passive Publishing** occurs when messages are generated as a side effect of a state change, often without the direct, explicit intervention of the business logic that caused the change. This is typically handled by an intermediary component that observes the state and generates messages accordingly.
+
+*   **Characteristics:**
+    *   **Implicit:** The business logic that changes the state may be completely unaware that a message is being published.
+    *   **Observational:** Based on observing changes to a system's state, such as a database table or an object's properties.
+    *   **Decoupled from Business Logic:** The publishing mechanism is external to the code that triggers the state change.
+
+*   **Example:**
+    The `quanta_memora` project generation tool maintains its project metadata in a central database. Instead of adding code to every function that modifies this data, a **Change Data Capture (CDC)** tool is configured to monitor the project metadata table. When the CDC tool detects an `INSERT` or `UPDATE` operation, it automatically formats the change into a `project.metadata.updated` event and publishes it to the message bus. The `quanta_memora` application code simply performs its database operations, oblivious to the publishing that happens passively in the background.
+
+This passive approach is powerful for integrating with legacy systems or for ensuring that every state change is captured and broadcast without having to manually instrument every piece of code.


### PR DESCRIPTION
This commit adds a new section to the publisher-subscriber architecture documentation. The new section defines and differentiates between active and passive publishing models, providing examples for each within the QuantaSynapse context.